### PR TITLE
Update messages.json

### DIFF
--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -780,7 +780,7 @@
   },
   
   "Hotkey": {
-    "message": "Raccourci clavier",
+    "message": "Touche d’accès",
     "description": "label for Hotkey option"
   },
   


### PR DESCRIPTION
"Raccourci clavier" was too long for the table in the quickmenu options tab. (icon too close)