### PR TITLE
1.16

### DIFF
--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1517,6 +1517,14 @@
 	"message": "Le menu contextuel standard est obtenu en maintenant le bouton droit enfoncé pendant environ une seconde puis en le relâchant."
   },
   
+  "tools_repeatsearch": {
+    "message": "Effectuer une recherche clic gauche avec le dernier moteur utilisé à l’ouverture du menu"
+  },
+  
+  "tools_lastused": {
+    "message": "Dernier moteur de recherche utilisé"
+  },
+  
   "___________": {
     "message": "",
     "description": ""


### PR DESCRIPTION
Two more translation lacks:

- When editing a bookmarklet added in the search engines manager, the field `Icon URI` is not translated nor the `save` and `close` buttons label.

- Suggestion: have the ability to translate "Clear highlighting" icon title (I guess by replacing page_action default_title by `__MSG_ClearHighlighting__` (for example) in the manifest and adding string in locales?)