### PR TITLE
Add the shortcut to toggle Firefox sidebar

### DIFF
--- a/src/firefox_manifest.json
+++ b/src/firefox_manifest.json
@@ -86,7 +86,8 @@
 		"open_at_install": false
 	},
 	"commands": {
-		"_execute_browser_action": {}
+		"_execute_browser_action": {},
+		"_execute_sidebar_action": {}
 	},
 	"omnibox": {
 		"keyword": "cs"


### PR DESCRIPTION
Fix [#541](https://github.com/ssborbis/ContextSearch-web-ext/issues/541).

Add a shortcut to toggle the Firefox sidebar and make it easier for users to see and close the search results in the sidebar.